### PR TITLE
fix: position back button arrow

### DIFF
--- a/src/components/ButtonBackIcon/ButtonBackIcon.css
+++ b/src/components/ButtonBackIcon/ButtonBackIcon.css
@@ -1,4 +1,7 @@
 .c-btn-back-icon {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
## Description

Repair button back arrow position because don't appear in same position at all views.

## Type of Change

<!-- Mark with an "x" the ones that apply -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement of an existing feature)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation (changes or additions to documentation)
- [ ] Other (please specify):

## Related Issues

https://trello.com/c/dQCF6vnm

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/143d1e65-c034-4c30-9046-47cd1c87a7b8)

After: 
![image](https://github.com/user-attachments/assets/b273b6db-1191-4746-8c39-73e17f543b1f)

